### PR TITLE
Fix EF Core query

### DIFF
--- a/src/infrastructure/Roborally.infrastructure.persistence/Lobby/GameLobbyRepository.cs
+++ b/src/infrastructure/Roborally.infrastructure.persistence/Lobby/GameLobbyRepository.cs
@@ -20,6 +20,6 @@ public class GameLobbyRepository : IGameLobbyRepository
     public async Task<bool> IsUserCurrentlyHostingActiveLobbyAsync(Guid hostUserId)
     {
         return await _context.GameLobby
-            .AnyAsync(x => x.HostId == hostUserId && x.IsActive);
+            .AnyAsync(x => x.HostId == hostUserId && x.StartedAt == null);
     }
 }


### PR DESCRIPTION
- Replaced the usage of the computed property IsActive in GameLobbyRepository with an explicit StartedAt == null check.

- EF Core couldn’t translate the IsActive getter to SQL, causing an InvalidOperationException when checking for an active lobby.

- This change makes the query fully translatable and resolves the 500 error when creating a game lobby.